### PR TITLE
Small performance improvement.

### DIFF
--- a/src/SymRCM.jl
+++ b/src/SymRCM.jl
@@ -104,29 +104,31 @@ function symrcm_sorted(graph::AbstractGraph{V}) where V
     label = fill(false, nv(graph))
     order = Vector{V}(undef, nv(graph))
 
-    # find psuedo-peripheral vertex
-    root = argmin(vertices(graph)) do i
-        degree(graph, i)
-    end
+    if nv(graph) > 0
+        # find psuedo-peripheral vertex
+        root = argmin(vertices(graph)) do i
+            degree(graph, i)
+        end
 
-    # compute Cuthill-Mckee ordering
-    component, stack = bfs!(label, order, graph, root)
+        # compute Cuthill-Mckee ordering
+        component, stack = bfs!(label, order, graph, root)
 
-    for j in vertices(graph)
-        if !label[j]
-            # compute connected component
-            component, stack = bfs!(label, stack, graph, j)
+        for j in vertices(graph)
+            if !label[j]
+                # compute connected component
+                component, stack = bfs!(label, stack, graph, j)
 
-            # find psuedo-peripheral vertex
-            root = argmin(component) do i
-                degree(graph, i)
+                # find psuedo-peripheral vertex
+                root = argmin(component) do i
+                    degree(graph, i)
+                end
+
+                # reset labels
+                label[component] .= false
+
+                # compute Cuthill-Mckee ordering
+                bfs!(label, component, graph, root)
             end
-
-            # reset labels
-            label[component] .= false
-
-            # compute Cuthill-Mckee ordering
-            bfs!(label, component, graph, root)
         end
     end
 

--- a/src/SymRCM.jl
+++ b/src/SymRCM.jl
@@ -104,7 +104,7 @@ function symrcm_sorted(graph::AbstractGraph{V}) where V
     label = fill(false, nv(graph))
     order = Vector{V}(undef, nv(graph))
 
-    if nv(graph) > 0
+    if !iszero(nv(graph))
         # find psuedo-peripheral vertex
         root = argmin(vertices(graph)) do i
             degree(graph, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,7 +124,7 @@ function test()
     numbering = symrcm(ag, nd)
     # display(spy(A))
     # display(spy(A[numbering, numbering]))
-    @test numbering[end-4:end] == [22, 21, 20, 10, 9]
+    @test numbering[end-4:end] == [12, 16, 11, 4, 9]
 
     numbering1 = symrcm(ag, nd)
     numbering2 = symrcm(A)


### PR DESCRIPTION
Dear Dr. Krysl,

I removed the computation `sortperm(degrees)`. This reduces the complexity of the algorithm to O(mΔ) for a graph with m edges and maximum degree Δ.

Here are some benchmarks:

```
julia> using BenchmarkTools, MatrixMarket, SuiteSparseMatrixCollection, SymRCM

julia> ssmc = ssmc_db();

julia> name = "venturiLevel3";

julia> graph = mmread(joinpath(fetch_ssmc(ssmc[ssmc.name .== name, :], format="MM")[1], "$(name).mtx"));

julia> @benchmark symrcm(graph; sortbydeg=true)
```

Old version:

```Julia
BenchmarkTools.Trial: 24 samples with 1 evaluation per sample.
 Range (min … max):  185.848 ms … 275.471 ms  ┊ GC (min … max):  2.26% … 31.63%
 Time  (median):     190.734 ms               ┊ GC (median):     2.53%
 Time  (mean ± σ):   210.518 ms ±  36.154 ms  ┊ GC (mean ± σ):  11.88% ± 13.02%

  ▂▂▂█                                                           
  █████▅▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁█▁█▅ ▁
  186 ms           Histogram: frequency by time          275 ms <

 Memory estimate: 299.55 MiB, allocs estimate: 29.
```

New version:

```Julia
BenchmarkTools.Trial: 38 samples with 1 evaluation per sample.
 Range (min … max):  119.761 ms … 225.783 ms  ┊ GC (min … max): 0.00% … 43.97%
 Time  (median):     126.819 ms               ┊ GC (median):    2.60%
 Time  (mean ± σ):   134.008 ms ±  26.549 ms  ┊ GC (mean ± σ):  8.20% ± 11.46%

   ▂▅ █▂                                                         
  ▇██▇██▄▁▁▁▁▁▄▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▄▄ ▁
  120 ms           Histogram: frequency by time          226 ms <

 Memory estimate: 203.55 MiB, allocs estimate: 15.
```